### PR TITLE
feat: transparent background and hidden send button

### DIFF
--- a/ios/KeyboardComposerView.swift
+++ b/ios/KeyboardComposerView.swift
@@ -105,7 +105,7 @@ class KeyboardComposerView: ExpoView {
     clipsToBounds = false
 
     // Container background is handled natively so consumers don't have to wrap in an extra view.
-    containerView.backgroundColor = composerBackgroundColor()
+    containerView.backgroundColor = .clear
     containerView.layer.cornerRadius = 0
     containerView.clipsToBounds = false
 
@@ -117,7 +117,7 @@ class KeyboardComposerView: ExpoView {
     textView.backgroundColor = .clear
     textView.textColor = .label
     // Leave room for the send button (bottom-right) and the expand button (top-right).
-    textView.textContainerInset = UIEdgeInsets(top: 14, left: 12, bottom: 14, right: 56)
+    textView.textContainerInset = UIEdgeInsets(top: 14, left: 12, bottom: 14, right: 12)
     textView.textContainer.lineFragmentPadding = 0
     textView.textContainer.lineBreakMode = .byWordWrapping
     textView.isScrollEnabled = false
@@ -198,7 +198,6 @@ class KeyboardComposerView: ExpoView {
     super.traitCollectionDidChange(previousTraitCollection)
     // Ensure placeholder color stays correct when switching light/dark mode.
     placeholderLabel.textColor = placeholderColor()
-    containerView.backgroundColor = composerBackgroundColor()
     textView.textColor = .label
   }
 
@@ -505,6 +504,7 @@ class KeyboardComposerView: ExpoView {
     }
     let hasText = !textView.text.isEmpty
     sendButton.isEnabled = sendButtonEnabled && hasText
+    sendButton.isHidden = !sendButtonEnabled
     sendButton.alpha = sendButton.isEnabled ? 1.0 : 0.4
   }
 


### PR DESCRIPTION
## Summary

Resolves #10.

- **Transparent background**: `containerView.backgroundColor` is now `.clear` instead of a hardcoded grey, letting consumers control the background via their own wrapper or styles.
- **No more trait override**: Removed the `containerView.backgroundColor = composerBackgroundColor()` line from `traitCollectionDidChange` so consumer-provided backgrounds survive dark/light mode switches.
- **Hidden send button**: When `sendButtonEnabled={false}`, the send button is now fully hidden (`isHidden = true`) instead of just dimmed (alpha 0.4).
- **Reclaimed padding**: Reduced `textContainerInset.right` from `56` to `12` so the text input uses the full width when the send button is not present.

## Changed file

`ios/KeyboardComposerView.swift` — 4 targeted changes, no new files or APIs.

## Test plan

- [ ] Render `<ChatComposer sendButtonEnabled={false} />` and verify the send button is completely invisible with no reserved space on the right
- [ ] Render `<ChatComposer />` (default) and verify the send button appears and functions normally
- [ ] Verify the composer background is transparent (parent view background shows through)
- [ ] Toggle device between light and dark mode and confirm the background stays transparent (no grey flash)